### PR TITLE
Fix issue with Done button not working

### DIFF
--- a/src/Kingdom.js
+++ b/src/Kingdom.js
@@ -137,7 +137,7 @@ class Kingdom extends Component {
           <div className="col-lg-12">
             <h2>Ruler {username}</h2>
             {rulerAnimal ?
-              <p><a href={`${EXPLORER_URL}/name/${username}`} target="_blank">{username}</a> is a {rulerAnimal.name} that rules over the {rulerTerritory.name}.</p>
+              <p><a href={`${EXPLORER_URL}/name/${username}`} target="_blank" rel="noopener noreferrer">{username}</a> is a {rulerAnimal.name} that rules over the {rulerTerritory.name}.</p>
               :
               <p>{username} is an unknown animal that hails from an unknown land.</p>
             }


### PR DESCRIPTION
The first time running the app, clicking the Done button appears to not work. Console reveals a complaint about `_blank` not being safe and requiring `rel="noopener noreferrer"` in the href. Added the `rel` and it appears to solve the issue. I did see that at least one other person experienced the issue, reporting it in the forum.

https://forum.blockstack.org/t/buttons-dont-work-on-tutorial/6992