### PR TITLE
eslint: remove unused variable from import

### DIFF
--- a/src/EditMe.js
+++ b/src/EditMe.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
 import './EditMe.css'
 import Card from './Card'
-import { ANIMALS, TERRITORIES, ME_FILENAME } from './constants'
+import { ANIMALS, TERRITORIES } from './constants'
 
 class EditMe extends Component {
 


### PR DESCRIPTION
This fixes this ESlint issue:
`Line 5:  'ME_FILENAME' is defined but never used  no-unused-vars`